### PR TITLE
Add additional tests and implement negative-weight cycle check

### DIFF
--- a/shortestpaths/__init__.py
+++ b/shortestpaths/__init__.py
@@ -44,7 +44,12 @@ def _bellmanford(graph, source, monitor=None):
                 dist[v] = dist[u] + w
                 prev[v] = u
     tic()
-    # TODO: implement negative-weight cycle check if necessary
+    # Negative-weight cycle check
+    for key, w in graph["edges"].items():
+        u, v = key.split("->")
+        if dist[u] + w < dist[v]:
+            raise Exception("Negative-weight cycle detected")
+    tic()
     if monitor:
         return dist, prev, prof
     else:
@@ -123,7 +128,7 @@ def min_dist(Q, dist):
 def neighbors(Q, u, graph):
     neighbors = []
     for v in Q:
-        if graph["edges"][f"{u}->{v}"]:
+        if f"{u}->{v}" in graph["edges"]:
             neighbors.append(v)
     return neighbors
 

--- a/shortestpaths/tests/test_bellmanford.py
+++ b/shortestpaths/tests/test_bellmanford.py
@@ -25,3 +25,38 @@ def test_bellmanford_profiled():
     source = "A"
     dist, prev, prof = bellmanford(graph, source, True)
     assert dist == {'A': 0, 'B': 3, 'C': 5}
+
+
+from shortestpaths import bellmanford
+
+def test_bellmanford_simple_graph():
+    graph = {
+        "vertices": ["A", "B", "C", "D"],
+        "edges": {
+            "A->B": 2,
+            "A->C": 4,
+            "B->C": 1,
+            "B->D": 5,
+            "C->D": 3
+        }
+    }
+    source = "A"
+    dist, prev = bellmanford(graph, source)
+    assert dist == {'A': 0, 'B': 2, 'C': 3, 'D': 6}
+
+def test_bellmanford_negative_cycle():
+    graph = {
+        "vertices": ["A", "B", "C", "D"],
+        "edges": {
+            "A->B": 1,
+            "B->C": -1,
+            "C->D": -1,
+            "D->B": -1
+        }
+    }
+    source = "A"
+    try:
+        dist, prev = bellmanford(graph, source)
+        assert False, "Expected a negative cycle exception, but none was raised"
+    except Exception as e:
+        assert str(e) == "Negative-weight cycle detected"

--- a/shortestpaths/tests/test_dijkstra.py
+++ b/shortestpaths/tests/test_dijkstra.py
@@ -1,4 +1,5 @@
 import shortestpaths
+import math
 
 def test_dijkstra():
     graph = {
@@ -25,3 +26,36 @@ def test_dijkstra_profiled():
     source = "A"
     dist, prev, prof = shortestpaths.dijkstra(graph, source, True)
     assert dist == {'A': 0, 'B': 3, 'C': 5}
+
+
+from shortestpaths import dijkstra
+
+def test_dijkstra_simple_graph():
+    graph = {
+        "vertices": ["A", "B", "C", "D"],
+        "edges": {
+            "A->B": 2,
+            "A->C": 4,
+            "B->C": 1,
+            "B->D": 5,
+            "C->D": 3
+        }
+    }
+    source = "A"
+    dist, prev = dijkstra(graph, source)
+    assert dist == {'A': 0, 'B': 2, 'C': 3, 'D': 6}
+
+def test_dijkstra_disconnected_graph():
+    graph = {
+        "vertices": ["A", "B", "C", "D", "E"],
+        "edges": {
+            "A->B": 2,
+            "A->C": 4,
+            "B->C": 1,
+            "B->D": 5,
+            "C->D": 3
+        }
+    }
+    source = "A"
+    dist, prev = dijkstra(graph, source)
+    assert dist == {'A': 0, 'B': 2, 'C': 3, 'D': 6, 'E': math.inf}

--- a/shortestpaths/tests/test_floydwarshall.py
+++ b/shortestpaths/tests/test_floydwarshall.py
@@ -25,3 +25,36 @@ def test_floydwarshall_profiled():
     source = "A"
     dist, prev, prof = floydwarshall(graph, source, True)
     assert dist == {'A': 0, 'B': 3, 'C': 5}
+
+
+from shortestpaths import floydwarshall
+
+def test_floydwarshall_simple_graph():
+    graph = {
+        "vertices": ["A", "B", "C", "D"],
+        "edges": {
+            "A->B": 2,
+            "A->C": 4,
+            "B->C": 1,
+            "B->D": 5,
+            "C->D": 3
+        }
+    }
+    source = "A"
+    dist, prev = floydwarshall(graph, source)
+    assert dist == {'A': 0, 'B': 2, 'C': 3, 'D': 6}
+
+def test_floydwarshall_negative_weights():
+    graph = {
+        "vertices": ["A", "B", "C", "D"],
+        "edges": {
+            "A->B": 2,
+            "A->C": -4,
+            "B->C": 1,
+            "B->D": 5,
+            "C->D": 3
+        }
+    }
+    source = "A"
+    dist, prev = floydwarshall(graph, source)
+    assert dist == {'A': 0, 'B': 2, 'C': -4, 'D': -1}


### PR DESCRIPTION
- Added 2 test cases to each algorithm:
   - test_bellmanford_simple_graph()
   - test_bellmanford_negative_cycle()
   - test_floydwarshall_simple_graph()
   - test_floydwarshall_negative_weights()
   - test_dijkstra_simple_graph()
   - test_dijkstra_disconnected_graph()

- Expanded the test suite for Floyd-Warshall, Dijkstra, and Bellmanfordalgorithms checking different scenarios, such as negative weights and disconnected graphs. Enhanced the Bellmanford's algorithm to detect negative-weight cycles.

- Minor fix in the 'neighbors' function was also added to ensure a key exists in the graph's edges.